### PR TITLE
Fix reference-cast compile error

### DIFF
--- a/include/hlsl++/dependent.h
+++ b/include/hlsl++/dependent.h
@@ -99,38 +99,38 @@ hlslpp_module_export namespace hlslpp
 	//-----------------------
 
 	hlslpp_inline float asfloat(const uint v) { return detail::packed_union(v)._f32; }
-	hlslpp_inline float1 asfloat(const uint1& v) { return (float1&)v; }
-	hlslpp_inline float2 asfloat(const uint2& v) { return (float2&)v; }
-	hlslpp_inline float3 asfloat(const uint3& v) { return (float3&)v; }
-	hlslpp_inline float4 asfloat(const uint4& v) { return (float4&)v; }
+	hlslpp_inline float1 asfloat(const uint1& v) { return (const float1&)v; }
+	hlslpp_inline float2 asfloat(const uint2& v) { return (const float2&)v; }
+	hlslpp_inline float3 asfloat(const uint3& v) { return (const float3&)v; }
+	hlslpp_inline float4 asfloat(const uint4& v) { return (const float4&)v; }
 
 	hlslpp_inline float asfloat(const int v) { return detail::packed_union(v)._f32; }
-	hlslpp_inline float1 asfloat(const int1& v) { return (float1&)v; }
-	hlslpp_inline float2 asfloat(const int2& v) { return (float2&)v; }
-	hlslpp_inline float3 asfloat(const int3& v) { return (float3&)v; }
-	hlslpp_inline float4 asfloat(const int4& v) { return (float4&)v; }
+	hlslpp_inline float1 asfloat(const int1& v) { return (const float1&)v; }
+	hlslpp_inline float2 asfloat(const int2& v) { return (const float2&)v; }
+	hlslpp_inline float3 asfloat(const int3& v) { return (const float3&)v; }
+	hlslpp_inline float4 asfloat(const int4& v) { return (const float4&)v; }
 
 	hlslpp_inline uint asuint(const int v) { return detail::packed_union(v)._u32; }
-	hlslpp_inline uint1 asuint(const int1& v) { return (uint1&)v; }
-	hlslpp_inline uint2 asuint(const int2& v) { return (uint2&)v; }
-	hlslpp_inline uint3 asuint(const int3& v) { return (uint3&)v; }
-	hlslpp_inline uint4 asuint(const int4& v) { return (uint4&)v; }
+	hlslpp_inline uint1 asuint(const int1& v) { return (const uint1&)v; }
+	hlslpp_inline uint2 asuint(const int2& v) { return (const uint2&)v; }
+	hlslpp_inline uint3 asuint(const int3& v) { return (const uint3&)v; }
+	hlslpp_inline uint4 asuint(const int4& v) { return (const uint4&)v; }
 
 	hlslpp_inline uint asuint(const float v) { return detail::packed_union(v)._u32; }
-	hlslpp_inline uint1 asuint(const float1& v) { return (uint1&)v; }
-	hlslpp_inline uint2 asuint(const float2& v) { return (uint2&)v; }
-	hlslpp_inline uint3 asuint(const float3& v) { return (uint3&)v; }
-	hlslpp_inline uint4 asuint(const float4& v) { return (uint4&)v; }
+	hlslpp_inline uint1 asuint(const float1& v) { return (const uint1&)v; }
+	hlslpp_inline uint2 asuint(const float2& v) { return (const uint2&)v; }
+	hlslpp_inline uint3 asuint(const float3& v) { return (const uint3&)v; }
+	hlslpp_inline uint4 asuint(const float4& v) { return (const uint4&)v; }
 
 	hlslpp_inline int asint(const uint v) { return detail::packed_union(v)._i32; }
-	hlslpp_inline int1 asint(const uint1& v) { return (int1&)v; }
-	hlslpp_inline int2 asint(const uint2& v) { return (int2&)v; }
-	hlslpp_inline int3 asint(const uint3& v) { return (int3&)v; }
-	hlslpp_inline int4 asint(const uint4& v) { return (int4&)v; }
+	hlslpp_inline int1 asint(const uint1& v) { return (const int1&)v; }
+	hlslpp_inline int2 asint(const uint2& v) { return (const int2&)v; }
+	hlslpp_inline int3 asint(const uint3& v) { return (const int3&)v; }
+	hlslpp_inline int4 asint(const uint4& v) { return (const int4&)v; }
 
 	hlslpp_inline int asint(const float v) { return detail::packed_union(v)._i32; }
-	hlslpp_inline int1 asint(const float1& v) { return (int1&)v; }
-	hlslpp_inline int2 asint(const float2& v) { return (int2&)v; }
-	hlslpp_inline int3 asint(const float3& v) { return (int3&)v; }
-	hlslpp_inline int4 asint(const float4& v) { return (int4&)v; }
+	hlslpp_inline int1 asint(const float1& v) { return (const int1&)v; }
+	hlslpp_inline int2 asint(const float2& v) { return (const int2&)v; }
+	hlslpp_inline int3 asint(const float3& v) { return (const int3&)v; }
+	hlslpp_inline int4 asint(const float4& v) { return (const int4&)v; }
 }


### PR DESCRIPTION
On clang i was getting a compilation error with gcc here due to the casting of a const-reference into a non-const-reference type.
